### PR TITLE
Update HeavenStem.java

### DIFF
--- a/src/main/java/com/tyme/sixtycycle/HeavenStem.java
+++ b/src/main/java/com/tyme/sixtycycle/HeavenStem.java
@@ -79,6 +79,18 @@ public class HeavenStem extends LoopTyme {
   }
 
   /**
+   * 十神（生我者，正印偏印。我生者，伤官食神。克我者，正官七杀。我克者，正财偏财。同我者，劫财比肩。）
+   *
+   * @param target 天干
+   * @return 十神
+   */
+  public TenStar getTenGod(HeavenStem target) {
+    int baseOffset = target.index - this.index;
+    int offset = (this.index % 2 != 0 && target.index % 2 == 0) ? baseOffset + 2 : baseOffset;
+    return TenStar.fromIndex(offset);
+  }
+
+  /**
    * 方位
    *
    * @return 方位


### PR DESCRIPTION
增加 getTenGod 方法 简化取十神代码,无需五行阴阳

测试代码如下:

import com.tyme.sixtycycle.HeavenStem;
import java.util.ArrayList;

public class 测试 {

    public static void main(String[] args) {
        ArrayList<String> 错误列表 = new ArrayList<String>();
        for (int i = 0; i < 10; i++) {
            HeavenStem 原天干 = HeavenStem.fromIndex(i);
            System.out.println(原天干.getName());
            for (int j = 0; j < 10; j++) {
                HeavenStem 目标天干 = HeavenStem.fromIndex(j);
                String 说明 = 原天干.getName() + " " + 目标天干.getName() + " " + 原天干.getTenStar(目标天干)+ " " + 原天干.getTenGod(目标天干);
                System.out.println(说明);
                if(!原天干.getTenStar(目标天干).equals(原天干.getTenGod(目标天干))){
                    错误列表.add(说明);
                }
            }
        }
        System.out.println("__________________________以下为错误信息为,为空则无测错_______________________________");
        for (String 错误 : 错误列表) {
            System.out.println(错误);
        }
    }
}